### PR TITLE
fix: 修复Cloudflare质询循环问题

### DIFF
--- a/linuxdo-scripts.user.js
+++ b/linuxdo-scripts.user.js
@@ -23,6 +23,10 @@
 (function (vue, pangu, marked, $$1) {
   'use strict';
 
+  if (document.getElementById('challenge-form')) {
+      return;
+  }
+
   const name = "linuxdo-scripts";
   const version = "0.3.70";
   const author = "dlzmoe";


### PR DESCRIPTION
## 1. 证明前一版本中行为不正确

当 Cloudflare 进行 CAPTCHA 质询时, 访问者在完成 CAPTCHA 质询后, 页面重新加载, 并且访问者被提示再次完成 CAPTCHA 质询, 具体原因未知. 

## 2. 修复方法

该更新通过如下方法修复此问题:
1. 当质询页面显示时, CAPTCHA 部分通过一个ID为 `challenge-form` 的表单展示. 
2. 因此, 该更新在检测到 `challenge-form` 元素时, 自动终止脚本. 