### PR TITLE
feat: 显示“楼主”标识功能；打开帖子时始终打开一楼的功能

### DIFF
--- a/entrypoints/App.vue
+++ b/entrypoints/App.vue
@@ -143,6 +143,8 @@
             <MenuMonitorWidthOptimization :sort="37" v-model="settingData.checked46" />
             <!-- 类别页优化 banner 显示 -->
             <MenuCatePageOptimizeBanner :sort="38" v-model="settingData.checked47" />
+            <!-- 楼主头衔显示 -->
+            <MenuTopicOwnerBadge :sort="39" v-model="settingData.checked49" />
           </div>
           <div class="menu-body-item" v-show="activeIndex == 1">
             <!-- 自定义论坛 logo -->
@@ -240,6 +242,7 @@ import MenuViewOwnReply from "./components/BasicSettings/MenuViewOwnReply.vue";
 import MenuUsernameLength from "./components/BasicSettings/MenuUsernameLength.vue";
 import MenuMonitorWidthOptimization from "./components/BasicSettings/MenuMonitorWidthOptimization.vue";
 import MenuCatePageOptimizeBanner from "./components/BasicSettings/MenuCatePageOptimizeBanner.vue";
+import MenuTopicOwnerBadge from "./components/BasicSettings/MenuTopicOwnerBadge.vue";
 
 // 自定义文字
 import MenuOtherCss from "./components/CustomText/MenuOtherCss.vue";
@@ -356,6 +359,7 @@ export default {
     MenuIconTitle,
     MenuCatePageOptimizeBanner,
     MenuUserTags,
+    MenuTopicOwnerBadge,
   },
   data() {
     return {
@@ -429,6 +433,7 @@ export default {
         checked46: false,
         checked47: false,
         checked48: false,
+        checked49: false,
         removePostavatarData: {
           enable: false,
           showAuthor: false,

--- a/entrypoints/App.vue
+++ b/entrypoints/App.vue
@@ -145,6 +145,8 @@
             <MenuCatePageOptimizeBanner :sort="38" v-model="settingData.checked47" />
             <!-- 楼主头衔显示 -->
             <MenuTopicOwnerBadge :sort="39" v-model="settingData.checked49" />
+            <!-- 始终打开1楼 -->
+            <MenuAlwaysFirstPost :sort="40" v-model="settingData.checked50" />
           </div>
           <div class="menu-body-item" v-show="activeIndex == 1">
             <!-- 自定义论坛 logo -->
@@ -243,6 +245,7 @@ import MenuUsernameLength from "./components/BasicSettings/MenuUsernameLength.vu
 import MenuMonitorWidthOptimization from "./components/BasicSettings/MenuMonitorWidthOptimization.vue";
 import MenuCatePageOptimizeBanner from "./components/BasicSettings/MenuCatePageOptimizeBanner.vue";
 import MenuTopicOwnerBadge from "./components/BasicSettings/MenuTopicOwnerBadge.vue";
+import MenuAlwaysFirstPost from "./components/BasicSettings/MenuAlwaysFirstPost.vue";
 
 // 自定义文字
 import MenuOtherCss from "./components/CustomText/MenuOtherCss.vue";
@@ -360,6 +363,7 @@ export default {
     MenuCatePageOptimizeBanner,
     MenuUserTags,
     MenuTopicOwnerBadge,
+    MenuAlwaysFirstPost,
   },
   data() {
     return {
@@ -434,6 +438,7 @@ export default {
         checked47: false,
         checked48: false,
         checked49: false,
+        checked50: false, 
         removePostavatarData: {
           enable: false,
           showAuthor: false,

--- a/entrypoints/components/BasicSettings/MenuAlwaysFirstPost.vue
+++ b/entrypoints/components/BasicSettings/MenuAlwaysFirstPost.vue
@@ -1,0 +1,165 @@
+<template>
+  <div class="item">
+    <div class="tit">{{ sort }}. 始终打开1楼</div>
+    <input type="checkbox" :checked="modelValue" @change="$emit('update:modelValue', $event.target.checked)" />
+  </div>
+</template>
+
+<script>
+import $ from "jquery";
+export default {
+  props: ["modelValue", "sort"],
+  emits: ["update:modelValue"],
+  data() {
+    return {
+      processingUrl: false,
+      originalUrl: null,
+      intervalId: null,
+    };
+  },
+  created() {
+    if (this.modelValue) {
+      this.$nextTick(() => {
+        this.originalUrl = window.location.href;
+        
+        // 处理当前URL
+        this.redirectToFirstPost();
+        
+        // 开始链接监控
+        this.startLinkMonitoring();
+        
+        // 监听浏览器前进后退
+        window.addEventListener('popstate', this.handlePopState);
+      });
+    }
+  },
+  methods: {
+    /**
+     * 开始监控页面上的所有链接
+     */
+    startLinkMonitoring() {
+      // 清除可能已有的监控
+      this.stopLinkMonitoring();
+      
+      // 立即处理一次
+      this.modifyTopicLinks();
+      
+      // 设置定时监控，处理动态加载的内容
+      this.intervalId = setInterval(() => {
+        this.modifyTopicLinks();
+      }, 1000);
+    },
+    
+    /**
+     * 停止链接监控
+     */
+    stopLinkMonitoring() {
+      if (this.intervalId) {
+        clearInterval(this.intervalId);
+        this.intervalId = null;
+      }
+    },
+    
+    /**
+     * 修改页面上所有带楼层参数的链接
+     */
+    modifyTopicLinks() {
+      // 处理所有站内链接
+      $("a").each((_, element) => {
+        const $el = $(element);
+        const href = $el.attr("href");
+        
+        if (!href) return;
+        
+        // 匹配带楼层参数的话题链接
+        const pattern = /\/t\/topic\/(\d+)\/\d+/;
+        const match = href.match(pattern);
+        
+        if (match) {
+          // 找到话题ID
+          const topicId = match[1];
+          
+          // 构建不带楼层参数的URL
+          if (href.startsWith('http')) {
+            // 完整URL
+            const urlObj = new URL(href);
+            const baseUrl = `${urlObj.protocol}//${urlObj.host}`;
+            const newUrl = `${baseUrl}/t/topic/${topicId}/`;
+            $el.attr("href", newUrl);
+          } else {
+            // 相对URL
+            const newUrl = `/t/topic/${topicId}/`;
+            $el.attr("href", newUrl);
+          }
+        }
+      });
+    },
+    
+    /**
+     * 处理popstate事件（浏览器前进/后退按钮）
+     */
+    handlePopState() {
+      if (!this.processingUrl) {
+        this.redirectToFirstPost();
+      }
+    },
+    
+    /**
+     * 修改当前页面URL，移除楼层参数
+     */
+    redirectToFirstPost() {
+      // 防止处理循环
+      if (this.processingUrl) return;
+      this.processingUrl = true;
+      
+      try {
+        // 检查当前URL是否是帖子页面，并且包含楼层参数
+        const currentUrl = window.location.href;
+        const topicRegex = /\/t\/topic\/(\d+)\/(\d+)/;
+        const match = currentUrl.match(topicRegex);
+        
+        if (match) {
+          const topicId = match[1];
+          
+          // 构建指向1楼的URL
+          const baseUrl = window.location.origin;
+          const pathWithoutFloor = `/t/topic/${topicId}/`;
+          const newUrl = `${baseUrl}${pathWithoutFloor}`;
+          
+          // 只在URL不同时才执行替换
+          if (currentUrl !== newUrl) {
+            // 使用replaceState修改URL，不刷新页面
+            window.history.replaceState(
+              history.state, 
+              document.title, 
+              pathWithoutFloor
+            );
+          }
+        }
+      } finally {
+        // 释放处理锁
+        setTimeout(() => {
+          this.processingUrl = false;
+        }, 100);
+      }
+    }
+  },
+  beforeUnmount() {
+    // 清理资源
+    this.stopLinkMonitoring();
+    window.removeEventListener('popstate', this.handlePopState);
+  },
+  watch: {
+    modelValue(newVal) {
+      if (newVal) {
+        this.redirectToFirstPost();
+        this.startLinkMonitoring();
+        window.addEventListener('popstate', this.handlePopState);
+      } else {
+        this.stopLinkMonitoring();
+        window.removeEventListener('popstate', this.handlePopState);
+      }
+    }
+  }
+};
+</script> 

--- a/entrypoints/components/BasicSettings/MenuTopicOwnerBadge.vue
+++ b/entrypoints/components/BasicSettings/MenuTopicOwnerBadge.vue
@@ -1,0 +1,190 @@
+<template>
+  <div class="item">
+    <div class="tit">{{ sort }}. 是否在楼主名字后显示楼主标识</div>
+    <input type="checkbox" :checked="modelValue" @change="$emit('update:modelValue', $event.target.checked)" />
+  </div>
+</template>
+
+<script>
+import $ from "jquery";
+export default {
+  props: ["modelValue", "sort"],
+  emits: ["update:modelValue"],
+  created() {
+    if (this.modelValue) {
+      // 添加楼主标识样式
+      $("head").append(`<style>
+/* 楼主标识基本样式 */
+.topic-owner-badge {
+  /* 基础布局属性 */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  
+  /* 尺寸与间距 */
+  min-width: 36px;
+  height: 22px; /* 增加高度确保文字完整显示 */
+  line-height: 20px; /* 确保文字垂直居中 */
+  padding: 0px 8px;
+  margin-left: 8px;
+  vertical-align: middle;
+  
+  /* 文字样式 */
+  color: rgba(255, 255, 255, 0.95);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.15);
+  
+  /* 背景样式 */
+  background-color: var(--tertiary, #0088cc);
+  background-image: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.05) 50%,
+    rgba(0, 0, 0, 0.05) 51%,
+    rgba(0, 0, 0, 0.1) 100%
+  );
+  
+  /* 边框与圆角 */
+  border-radius: 3px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-sizing: border-box;
+  
+  /* 阴影效果 */
+  box-shadow: 
+    0 1px 2px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.15);
+  
+  /* 动画过渡效果 */
+  transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  
+  /* 其他装饰性效果 */
+  overflow: hidden;
+  z-index: 1;
+}
+
+/* 鼠标悬停状态 */
+.topic-owner-badge:hover {
+  /* 悬停时稍微放大 */
+  transform: translateY(-1px) scale(1.03);
+  
+  /* 增强阴影效果 */
+  box-shadow: 
+    0 2px 4px rgba(0, 0, 0, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.25);
+  
+  /* 调整文字颜色 */
+  color: rgba(255, 255, 255, 1);
+  
+  /* 调整背景 */
+  background-image: linear-gradient(
+    135deg,
+    rgba(255, 255, 255, 0.15) 0%,
+    rgba(255, 255, 255, 0.08) 50%,
+    rgba(0, 0, 0, 0.08) 51%,
+    rgba(0, 0, 0, 0.15) 100%
+  );
+}
+
+/* 添加伪元素装饰 */
+.topic-owner-badge::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 50%;
+  background: linear-gradient(
+    to bottom,
+    rgba(255, 255, 255, 0.12) 0%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  z-index: -1;
+}
+
+/* 添加伪元素闪光效果 */
+.topic-owner-badge::after {
+  content: "";
+  position: absolute;
+  top: -50%;
+  left: -100%;
+  width: 40%;
+  height: 200%;
+  background: linear-gradient(
+    to right,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    rgba(255, 255, 255, 0) 100%
+  );
+  transform: rotate(25deg);
+  z-index: 2;
+  opacity: 0;
+  transition: all 1.2s ease-in-out;
+}
+
+/* 鼠标悬停时触发闪光动画 */
+.topic-owner-badge:hover::after {
+  left: 200%;
+  opacity: 0.8;
+}
+
+/* 深色主题适配 */
+@media (prefers-color-scheme: dark) {
+  .topic-owner-badge {
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    box-shadow: 
+      0 1px 3px rgba(0, 0, 0, 0.15),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  }
+}
+
+/* 在页面加载时添加淡入效果 */
+@keyframes badgeFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* 应用页面加载动画 */
+.topic-post:not(.seen-owner-badge) .topic-owner-badge {
+  animation: badgeFadeIn 0.3s ease-out forwards;
+}
+
+/* 标记已经显示过徽章的帖子 */
+.topic-post.seen-owner-badge .topic-owner-badge {
+  /* 已经展示过的徽章不重复动画 */
+  animation: none;
+}
+}
+</style>`);
+      
+      // 监听帖子内容变化并添加楼主标识
+      let pollinglength = 0;
+      setInterval(() => {
+        if (pollinglength != $(".post-stream .topic-post").length) {
+          pollinglength = $(".post-stream .topic-post").length;
+          this.addTopicOwnerBadge();
+        }
+      }, 1000);
+    }
+  },
+  methods: {
+    addTopicOwnerBadge() {
+      // 为每个楼主帖子添加楼主标识
+      $(".post-stream .topic-post.topic-owner").each(function() {
+        // 检查是否已经添加了楼主标识
+        if ($(this).find(".topic-owner-badge").length < 1) {
+          $(this).find(".names").append(`<span class="topic-owner-badge">楼主</span>`);
+        }
+      });
+    }
+  }
+};
+</script> 


### PR DESCRIPTION
本PR新增了两个功能：显示“楼主”标识功能；打开帖子时始终打开一楼的功能
1. 显示“楼主”标识功能：在楼主的用户名之后，显示“楼主”标识。 #173 
![image](https://github.com/user-attachments/assets/429c3b79-8464-4469-b45b-278831deefdf)
2. 增加打开帖子时始终打开一楼的功能。#  #172 
   默认关闭情况下，打开一个帖子时，会回到上次浏览的楼层；打开功能后，不会到上次位置，而是直接回到一楼
   默认关闭情况，回到上次位置
![image](https://github.com/user-attachments/assets/91550b34-7d26-48bc-a0df-992d626236d6)
   打开开关情况，默认回到一楼
![image](https://github.com/user-attachments/assets/eabb0302-b339-4b81-87ad-44559e37f946)

两个功能的开关都添加到了插件设置中
![image](https://github.com/user-attachments/assets/90e45bfa-436f-4147-9d21-ec9cb29b7291)

