### PR TITLE
修复搜索页面链接无法在新标签页打开的问题

### DIFF
--- a/entrypoints/components/BasicSettings/MenuOpenpostblank.vue
+++ b/entrypoints/components/BasicSettings/MenuOpenpostblank.vue
@@ -21,8 +21,8 @@ export default {
 
       // 主要功能
       function processLinks() {
-        // 查找所有帖子标题链接
-        const links = document.querySelectorAll('.link-top-line a.title:not([data-processed])');
+        // 查找所有帖子标题链接，扩展选择器以包含搜索页面的链接
+        const links = document.querySelectorAll('.link-top-line a.title:not([data-processed]), .search-results a.search-link:not([data-processed]), .search-result-topic a:not([data-processed])');
 
         links.forEach(link => {
           // 标记该链接已处理
@@ -38,7 +38,11 @@ export default {
           return Array.from(mutation.addedNodes).some(node => {
             return node.nodeType === 1 && (
               node.classList.contains('link-top-line') ||
-              node.querySelector('.link-top-line')
+              node.querySelector('.link-top-line') ||
+              node.classList.contains('search-results') ||
+              node.querySelector('.search-results') ||
+              node.classList.contains('search-result-topic') ||
+              node.querySelector('.search-result-topic')
             );
           });
         });


### PR DESCRIPTION
问题描述
当启用"新标签页打开话题"功能时，搜索页面中的帖子链接无法正常在新标签页打开。

详见问题报告: #193

解决方案
1. 扩展链接选择器，增加搜索页面DOM结构的支持：
   - 添加了 `.search-results a.search-link:not([data-processed])`
   - 添加了 `.search-result-topic a:not([data-processed])`

2. 同时更新MutationObserver中的DOM变化检测逻辑，确保动态加载的搜索结果也能正确应用新标签页打开功能：
   - 添加了对 `search-results` 和 `search-result-topic` 类名的监听
