### PR TITLE
fix: 修复 Horizon 风格下“新标签页打开话题”失效

### DIFF
--- a/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
+++ b/entrypoints/SettingComponents/BasicSettings/MenuOpenpostblank.vue
@@ -9,27 +9,66 @@
 export default {
   props: ["modelValue", "sort"],
   emits: ["update:modelValue"],
-  created() {
-      if (this.modelValue) {
-        function handleLinkClick(e) {
-          const linkSelector='.link-top-line a.raw-link, .search-results a.search-link, .search-result-topic a.search-link'
-          // 检查被点击的元素或其父元素是否是要找的<a>标签
-          const link = e.target.closest(linkSelector);
-          
-          if (link && link.href) {
-            e.preventDefault();
-            e.stopPropagation();
-            e.stopImmediatePropagation();
-            
-            window.open(link.href, '_blank', 'noopener,noreferrer');
-          }
-        }
-        
-        // 使用事件委托，在 body 上监听一次即可，无需 MutationObserver
-        // 使用 { capture: true } 在捕获阶段拦截事件，确保最高优先级
-        document.body.addEventListener('click', handleLinkClick, { capture: true });
+  data() {
+    return {
+      handleLinkClick: null,
+    };
+  },
+  watch: {
+    modelValue(newVal) {
+      if (newVal) {
+        this.bindClickHandler();
+      } else {
+        this.unbindClickHandler();
       }
     },
+  },
+  methods: {
+    bindClickHandler() {
+      if (this.handleLinkClick) return;
 
+      const linkSelector = [
+        ".topic-list-item a.raw-topic-link",
+        ".topic-list-item .link-top-line a.raw-link",
+        ".topic-list-item a.topic-excerpt",
+        ".search-results a.search-link",
+        ".search-result-topic a.search-link",
+      ].join(", ");
+
+      this.handleLinkClick = (e) => {
+        if (!(e.target instanceof Element) || e.defaultPrevented || e.button !== 0) {
+          return;
+        }
+
+        const link = e.target.closest(linkSelector);
+
+        if (!link?.href) {
+          return;
+        }
+
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+
+        window.open(link.href, "_blank", "noopener,noreferrer");
+      };
+
+      document.body.addEventListener("click", this.handleLinkClick, true);
+    },
+    unbindClickHandler() {
+      if (!this.handleLinkClick) return;
+
+      document.body.removeEventListener("click", this.handleLinkClick, true);
+      this.handleLinkClick = null;
+    },
+  },
+  created() {
+    if (this.modelValue) {
+      this.bindClickHandler();
+    }
+  },
+  beforeUnmount() {
+    this.unbindClickHandler();
+  },
 };
 </script>


### PR DESCRIPTION
## Summary
- 修复 Horizon 风格下“是否新标签页打开话题”开启后不生效的问题
- 为话题标题与摘要补充 Horizon 卡片结构选择器，同时保留 Default / 搜索结果逻辑
- 为点击事件补充绑定/解绑，确保设置切换后立即生效

## Testing
- npm run build

Closes #326